### PR TITLE
Jmr/singular

### DIFF
--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -16,7 +16,7 @@ module Hangar
     private
 
     def resource
-      request.path.split('/')[2].singularize.to_sym
+      request.path.split('/')[2].to_sym
     end
 
     def resource_attributes

--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -1,8 +1,8 @@
 module Hangar
   class ResourcesController < ActionController::Base
 
-    rescue_from StandardError, :with => :error_render_method
-
+    resque_from ActiveRecord::RecordInvalid, with: :invalid_render_method
+    rescue_from StandardError, with: :error_render_method
     def create
       created = FactoryGirl.create resource, *traits, resource_attributes
       render json: created.as_json(include: includes)
@@ -36,6 +36,14 @@ module Hangar
       respond_to do |type|
         type.json { render :json => {error: exception.message}.to_json, :status => status_code}
         type.all { throw exception }
+      end
+      true
+    end
+
+    def invalid_render_method(exception)
+      status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code
+      respond_to do |type|
+        type.all { render :json => {error: exception.message, object: exception.record.to_json}.to_json, :status => status_code }
       end
       true
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   constraints Hangar::RouteConstraint.new do
-    FactoryGirl.factories.map(&:name).map(&:to_s).map(&:pluralize).map(&:to_sym).each do |factory|
+    FactoryGirl.factories.map(&:name).map(&:to_s).map(&:to_sym).each do |factory|
       namespace :hangar do
         resources factory, only: [:new, :create], controller: 'resources'
       end


### PR DESCRIPTION
Remove plural and singular symbol changes. We have factories in Candi which are already plural. Hangars attempt to move pluralize/singularize these broke those as a singular form factory did not exist.

Added error handling for ActiveRecord validation errors. 

Verified this will not effect mobile acceptance tests.
